### PR TITLE
Reestructurar relaciones Sale-Product con SaleProduct 

### DIFF
--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/dtos/ProductDTO.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/dtos/ProductDTO.java
@@ -1,12 +1,9 @@
 package com.supermercado.gestion_ventas.dtos;
 
-import com.supermercado.gestion_ventas.models.Sale;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashSet;
-import java.util.Set;
 
 @Data
 @NoArgsConstructor
@@ -16,5 +13,7 @@ public class ProductDTO {
     private String name;
     private double price;
     private String category;
-    private Set<SaleDTO> sales = new HashSet<>();
+    // TODO [ACTUALIZACIÓN DTO]: Se eliminó 'Set<SaleDTO> sales'.
+    // La relación Product-Sale ahora se gestiona vía SaleProduct para la cantidad.
+    // Este DTO de producto ya no contiene la lista completa de ventas para evitar sobrecarga y bucles.
 }

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/dtos/SaleDTO.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/dtos/SaleDTO.java
@@ -17,7 +17,9 @@ public class SaleDTO {
     private List<SaleDetailsDTO> saleDetails;
 
 
-    // DTO interno para el desglose de cada producto en la venta
+    // TODO [IMPORTANTE]: Clase interna para los detalles de cada producto en la venta.
+    // Esto es crucial para poder enviar la 'cantidad' de cada producto.
+    // Corresponde a la información que se mapeará a la nueva entidad SaleProduct.
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/Product.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/Product.java
@@ -1,5 +1,6 @@
 package com.supermercado.gestion_ventas.models;
 
+import com.supermercado.gestion_ventas.models.keys.SaleProduct;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,8 +25,11 @@ public class Product {
 
     private String category;
 
-    // Relación: Un Producto puede estar en muchas Ventas
-    @ManyToMany(mappedBy = "products")
-    private Set<Sale> sales = new HashSet<>();
+    // TODO [IMPORTANTE]: Cambio de relación con Sale.
+    // Antes: @ManyToMany(mappedBy = "products") private Set<Sale> sales;
+    // Ahora: La relación es a través de la entidad intermedia SaleProduct
+    // Esto permite almacenar la 'cantidad' de productos por venta.
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SaleProduct> saleProducts = new HashSet<>();
 
 }

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/Sale.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/Sale.java
@@ -1,4 +1,5 @@
 package com.supermercado.gestion_ventas.models;
+import com.supermercado.gestion_ventas.models.keys.SaleProduct;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,13 +25,10 @@ public class Sale {
 
     private LocalDate saleDate;
 
-    //Relación: Una Venta contiene muchos Productos
-    //Una Venta puede tener muchos Productos y un Producto puede estar en muchas Ventas
-    @ManyToMany
-    @JoinTable(
-            name = "sale_products",
-            joinColumns = @JoinColumn(name = "sale_id"),
-            inverseJoinColumns = @JoinColumn(name = "product_id")
-            )
-    private Set<Product> products = new HashSet<>();
+    // TODO [IMPORTANTE]: Cambio de relación con Product.
+    // Antes: @ManyToMany y @JoinTable directamente aquí.
+    // Ahora: La relación es a través de la entidad intermedia SaleProduct.
+    // Esto es NECESARIO para manejar la 'cantidad' de productos en cada venta.
+    @OneToMany(mappedBy = "sale", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SaleProduct> saleProducts = new HashSet<>();
 }

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/keys/SaleProduct.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/keys/SaleProduct.java
@@ -1,0 +1,38 @@
+package com.supermercado.gestion_ventas.models.keys;
+
+import com.supermercado.gestion_ventas.models.Product;
+import com.supermercado.gestion_ventas.models.Sale;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "sale_products")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleProduct {
+
+    @EmbeddedId
+    private SaleProductId id;
+
+    @ManyToOne
+    @MapsId("saleId")
+    @JoinColumn(name = "sale_id")
+    private Sale sale;
+
+    @ManyToOne
+    @MapsId("productId")
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private int quantity;
+
+    public SaleProduct(Sale sale, Product product, int quantity){
+        this.sale = sale;
+        this.product = product;
+        this.quantity = quantity;
+        this.id = new SaleProductId(sale.getId(), product.getId());
+    }
+}

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/keys/SaleProductId.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/models/keys/SaleProductId.java
@@ -1,0 +1,32 @@
+package com.supermercado.gestion_ventas.models.keys;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleProductId implements Serializable {
+    private Long saleId;
+    private Long productId;
+
+    @Override
+    public boolean equals(Object o){
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        SaleProductId that = (SaleProductId) o;
+        return Objects.equals(saleId, that.saleId) &&
+                Objects.equals(productId, that.productId);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(saleId, productId);
+    }
+}

--- a/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/repositories/SaleProductRepositoryInterfaz.java
+++ b/gestion-ventas/src/main/java/com/supermercado/gestion_ventas/repositories/SaleProductRepositoryInterfaz.java
@@ -1,0 +1,10 @@
+package com.supermercado.gestion_ventas.repositories;
+
+import com.supermercado.gestion_ventas.models.keys.SaleProduct;
+import com.supermercado.gestion_ventas.models.keys.SaleProductId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SaleProductRepositoryInterfaz extends JpaRepository<SaleProduct, SaleProductId> {
+}


### PR DESCRIPTION
Implemento la entidad SaleProduct para gestionar la cantidad de productos

Introduzco la entidad SaleProduct (y SaleProductId) para modelar correctamente la relación Many-to-Many entre Sale y Product, permitiendo almacenar la cantidad específica de cada producto en una venta.

Cambios realizados:
- Creé `SaleProductId` como clave compuesta.
- Creé `SaleProduct` como entidad intermedia con el campo `quantity`.
- Actualicé las entidades `Sale` y `Product` para usar `@OneToMany` hacia `SaleProduct` (eliminando los `@ManyToMany` directos).
- Ajusté los DTOs (`ProductDTO` y `SaleDTO`) para reflejar esta nueva estructura y evitar problemas de serialización.

**IMPORTANTE:** Es necesario actualizar la lógica en `SaleService` (y potencialmente otros servicios relacionados con ventas) para trabajar con `SaleProduct` al registrar y consultar ventas.